### PR TITLE
Add post body text to embedding text

### DIFF
--- a/lib/jekyll_ai_related_posts/generator.rb
+++ b/lib/jekyll_ai_related_posts/generator.rb
@@ -162,6 +162,7 @@ module JekyllAiRelatedPosts
       text = "Title: #{post.data["title"]}"
       text += "; Categories: #{post.data["categories"].join(", ")}" unless post.data["categories"].empty?
       text += "; Tags: #{post.data["tags"].join(", ")}" unless post.data["tags"].empty?
+      text += "; Body: #{post.content}"
 
       text
     end

--- a/spec/jekyll_ai_related_posts/generator_spec.rb
+++ b/spec/jekyll_ai_related_posts/generator_spec.rb
@@ -71,4 +71,20 @@ RSpec.describe JekyllAiRelatedPosts::Generator do
       site.process
     end
   end
+
+  it "includes body text in embedding_text" do
+    post = OpenStruct.new(
+      data: {
+        "title" => "Test Post",
+        "categories" => ["Category1"],
+        "tags" => ["Tag1"]
+      },
+      content: "This is the body text of the post."
+    )
+
+    generator = JekyllAiRelatedPosts::Generator.new
+    embedding_text = generator.send(:embedding_text, post)
+
+    expect(embedding_text).to include("Body: This is the body text of the post.")
+  end
 end


### PR DESCRIPTION
Fixes #1

Add body text to embedding text in `embedding_text` method.

* Modify `lib/jekyll_ai_related_posts/generator.rb` to append the body text to the `text` variable in the `embedding_text` method.
* Retrieve the body text of the post using `post.content`.
* Add a test case in `spec/jekyll_ai_related_posts/generator_spec.rb` to verify that the body text is included in the `embedding_text` method.

